### PR TITLE
Enabling ADVANCED_PAUSE_FEATURE to show the change filament menu

### DIFF
--- a/config/Hornet_Bltouch_UBL/Configuration.h
+++ b/config/Hornet_Bltouch_UBL/Configuration.h
@@ -1847,7 +1847,7 @@
  *    P1  Raise the nozzle always to Z-park height.
  *    P2  Raise the nozzle by Z-park amount, limited to Z_MAX_POS.
  */
-//#define NOZZLE_PARK_FEATURE
+#define NOZZLE_PARK_FEATURE
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z_raise }

--- a/config/Hornet_Bltouch_UBL/Configuration_adv.h
+++ b/config/Hornet_Bltouch_UBL/Configuration_adv.h
@@ -2347,7 +2347,7 @@
  *
  * Enable PARK_HEAD_ON_PAUSE to add the G-code M125 Pause and Park.
  */
-//#define ADVANCED_PAUSE_FEATURE
+#define ADVANCED_PAUSE_FEATURE
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
   #define PAUSE_PARK_RETRACT_FEEDRATE         60  // (mm/s) Initial retract feedrate.
   #define PAUSE_PARK_RETRACT_LENGTH            2  // (mm) Initial retract.


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

The change filament menu is missing if you use the configuration files from the config/Hornet_Bltouch_UBL folder.
I uncommented NOZZLE_PARK_FEATURE and ADVANCED_PAUSE_FEATURE and now the filament can be changed from the printer.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
No
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->
The users can change the filament from the printer menu.
